### PR TITLE
Use 'viewer' branch of build-variables by default

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ inputs:
   build-variables-ref:
     type: string
     description: build-variables repository ref
-    default: master
+    default: viewer
   build-id:
     type: string
     description: "Built id (default: commit sha)"


### PR DESCRIPTION
The viewer branch of [build-variables](https://github.com/secondlife/build-variables) contains changes which are required by 3p libraries, such as changes to macOS compile flags. We really should merge the viewer branch into master since it is the de facto branch, but until that is done use the viewer branch by default.