### PR TITLE
Add simple way to install autobuild git ref

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,3 +38,9 @@ jobs:
         with:
           checkout: false
           file: autobuild-scm.xml
+
+      # Test git-based autobuild install
+      - uses: ./
+        with:
+          version: main
+          checkout: false

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ jobs:
         os: [windows-2019, macos-11, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: secondlife/autobuild@v1
+      - uses: secondlife/action-autobuild@v3
+        with:
+          autobuild-version: 3.9.0 # PyPI version or git ref
 ```
 
 For a full list of available action inputs see [action.yaml](action.yaml).

--- a/action.yaml
+++ b/action.yaml
@@ -123,7 +123,12 @@ runs:
       env:
         VERSION: ${{ inputs.autobuild-version }}
       if: inputs.setup-autobuild
-      run: pip install autobuild==$VERSION
+      run: |
+        if [[ $VERSION = *.*.* ]]; then
+          pip install autobuild==$VERSION
+        else
+          pip install "autobuild @ git+https://github.com/secondlife/autobuild@$VERSION" 
+        fi
 
     - name: Setup cygwin
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
If version is not a semver then assume it's a git ref which can be used to install autobuild from its canonical repository. This will make testing CI/CD with in-development autobuild changes easier.