### PR TITLE
Add AUTOBUILD_GITHUB_TOKEN input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,5 +42,5 @@ jobs:
       # Test git-based autobuild install
       - uses: ./
         with:
-          version: main
+          autobuild-version: main
           checkout: false

--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,9 @@ inputs:
     type: string
     description: AUTOBUILD_ADDRSIZE
     default: "64"
+  token:
+    type: string
+    description: AUTOBUILD_GITHUB_TOKEN
   build-variables-ref:
     type: string
     description: build-variables repository ref
@@ -162,6 +165,7 @@ runs:
         AUTOBUILD: autobuild # Expected by some 3p build scripts
         AUTOBUILD_ADDRSIZE: ${{ inputs.addrsize }}
         AUTOBUILD_CONFIG_FILE: ${{ inputs.file }}
+        AUTOBUILD_GITHUB_TOKEN: ${{ inputs.token }}
         AUTOBUILD_INSTALLABLE_CACHE: ${{ github.workspace }}/.autobuild-installables
         AUTOBUILD_VARIABLES_FILE: ${{ github.workspace }}/.build-variables/variables
         AUTOBUILD_VCS_INFO: "true"


### PR DESCRIPTION
Allow users to pass a `token` input which will be used as AUTOBUILD_GITHUB_TOKEN. This will be necessary for pulling dependencies from private github repositories.