### PR TITLE
Set AUTOBUILD_VCS_BRANCH for an autobuild package.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -167,7 +167,7 @@ runs:
       shell: bash
       run: |
         branch="$(git branch -r --contains ${{ steps.sha.outputs.long }})"
-        echo "branch=${branch#*/}" >> "$GITHUB_OUTPUT"
+        echo "branch=${branch#*/}" >> $GITHUB_OUTPUT
 
     - name: Run autobuild
       shell: ${{ steps.shell.outputs.shell }}

--- a/action.yaml
+++ b/action.yaml
@@ -164,6 +164,7 @@ runs:
 
     - name: Determine branch
       id: which-branch
+      if: inputs.token
       uses: secondlife/viewer-build-util/which-branch@which-branch
       with:
         token: ${{ inputs.token }}
@@ -178,7 +179,7 @@ runs:
         AUTOBUILD_GITHUB_TOKEN: ${{ inputs.token }}
         AUTOBUILD_INSTALLABLE_CACHE: ${{ github.workspace }}/.autobuild-installables
         AUTOBUILD_VARIABLES_FILE: ${{ github.workspace }}/.build-variables/variables
-        AUTOBUILD_VCS_BRANCH: ${{ steps.which-branch.outputs.branch }}
+        AUTOBUILD_VCS_BRANCH: ${{ steps.which-branch.outputs.branch || github.ref_name }}
         AUTOBUILD_VCS_INFO: "true"
         BUILD_ID: ${{ inputs.build-id }}
         CONFIGURATION: ${{ inputs.configuration }}

--- a/action.yaml
+++ b/action.yaml
@@ -166,7 +166,9 @@ runs:
       id: which-branch
       shell: bash
       run: |
-        branch="$(git branch -r --contains ${{ steps.sha.outputs.long }})"
+        # in real use, 'git branch -r --contains' should produce a single line,
+        # but our self-tests can emit more than one
+        branch="$(git branch -r --contains ${{ steps.sha.outputs.long }} | head -n 1)"
         echo "branch=${branch#*/}" >> $GITHUB_OUTPUT
 
     - name: Run autobuild

--- a/action.yaml
+++ b/action.yaml
@@ -164,10 +164,10 @@ runs:
 
     - name: Determine branch
       id: which-branch
-      if: inputs.token
-      uses: secondlife/viewer-build-util/which-branch@which-branch
-      with:
-        token: ${{ inputs.token }}
+      shell: bash
+      run: |
+        branch="$(git branch -r --contains ${{ steps.sha.outputs.long }})"
+        echo "branch=${branch#*/}" >> "$GITHUB_OUTPUT"
 
     - name: Run autobuild
       shell: ${{ steps.shell.outputs.shell }}

--- a/action.yaml
+++ b/action.yaml
@@ -162,6 +162,12 @@ runs:
         path: ${{ github.workspace }}/.autobuild-installables
         key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.configuration }}-${{ hashFiles('autobuild.xml') }}
 
+    - name: Determine branch
+      id: which-branch
+      uses: secondlife/viewer-build-util/which-branch@which-branch
+      with:
+        token: ${{ inputs.token }}
+
     - name: Run autobuild
       shell: ${{ steps.shell.outputs.shell }}
       id: autobuild
@@ -172,6 +178,7 @@ runs:
         AUTOBUILD_GITHUB_TOKEN: ${{ inputs.token }}
         AUTOBUILD_INSTALLABLE_CACHE: ${{ github.workspace }}/.autobuild-installables
         AUTOBUILD_VARIABLES_FILE: ${{ github.workspace }}/.build-variables/variables
+        AUTOBUILD_VCS_BRANCH: ${{ steps.which-branch.outputs.branch }}
         AUTOBUILD_VCS_INFO: "true"
         BUILD_ID: ${{ inputs.build-id }}
         CONFIGURATION: ${{ inputs.configuration }}


### PR DESCRIPTION
It's useful to be able to look up the source branch from which a given autobuild package tarball was built. If `AUTOBUILD_VCS_BRANCH` is set in autobuild's environment, that gets stored in the package's `autobuild-package.xml`. Without it, every autobuild package's GitHub build's branch is reported as "HEAD".