### PR TITLE
Unconditionally use the GitHub workflow run ID as build ID.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -177,6 +177,7 @@ runs:
       env:
         AUTOBUILD: autobuild # Expected by some 3p build scripts
         AUTOBUILD_ADDRSIZE: ${{ inputs.addrsize }}
+        AUTOBUILD_BUILD_ID: ${{ github.run_id }}
         AUTOBUILD_CONFIG_FILE: ${{ inputs.file }}
         AUTOBUILD_GITHUB_TOKEN: ${{ inputs.token }}
         AUTOBUILD_INSTALLABLE_CACHE: ${{ github.workspace }}/.autobuild-installables
@@ -195,17 +196,6 @@ runs:
 
         use_scm_version="$(autobuild print --json | jq -j .package_description.use_scm_version)"
         use_scm_version="$(echo $use_scm_version | tr '[:upper:]' '[:lower:]')"
-
-        # Set AUTOBUILD_BUILD_ID
-        if [[ "$BUILD_ID" == "SHA" ]]; then
-          # Only default build ID to SHA if SCM version is disabled
-          if [[ "$use_scm_version" != "true" ]]; then
-            export AUTOBUILD_BUILD_ID="$SHORT_SHA"
-          fi
-        elif [[ ! -z "$BUILD_ID" ]]; then
-          # Allow an explicitly set build ID to be used
-          export AUTOBUILD_BUILD_ID="$BUILD_ID"
-        fi
 
         if [[ ! -z "$CONFIGURATION" ]]; then
           export AUTOBUILD_CONFIGURATION="$CONFIGURATION"


### PR DESCRIPTION
AUTOBUILD_BUILD_ID is captured in the package tarball's autobuild-package.xml as build_id. No other information in autobuild-package.xml permits uniquely identifying the build that constructed the package in question. The changeset hash could reference any of a number of builds of the same changeset.

Without knowing the specific build, we don't even know the date the package was built.