### PR TITLE
Upgrade to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: ./
         with:
+          artifact-name: autobuild-${{ matrix.os }}
           checkout: false
 
       - shell: bash
@@ -36,18 +37,21 @@ jobs:
 
       - uses: ./
         with:
+          artifact-name: autobuild-scm-${{ matrix.os }}
           checkout: false
           file: autobuild-scm.xml
 
       # Test git-based autobuild install
       - uses: ./
         with:
+          artifact-name: autobuild-git-${{ matrix.os }}
           autobuild-version: main
           checkout: false
       
       # Test alternative compression-format
       - uses: ./
         with:
+          artifact-name: autobuild-tbz2-${{ matrix.os }}
           archive-format: tbz2
           checkout: false
       - name: Check bz2 package
@@ -58,8 +62,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
       - uses: ./
         with:
+          artifact-name: autobuild-py310-${{ matrix.os }}
           setup-python: false
       - name: Check python version
         shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -60,6 +60,9 @@ inputs:
   configuration:
     type: string
     description: Autobuild configuration
+  artifact-name:
+    type: string
+    description: Name of artifact to upload, defaults to the autobuild package name
 
 outputs:
   package-name:
@@ -238,9 +241,9 @@ runs:
         echo "package_name=$package_name" >> $GITHUB_OUTPUT
         echo "package_platform=$package_platform" >> $GITHUB_OUTPUT
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: ${{ steps.results.outputs.package_basename_no_ext }}
+        name: ${{ inputs.artifact-name || steps.results.outputs.package_basename_no_ext }}
         path: |
           ${{ steps.results.outputs.package_filename }}
           autobuild-results.json


### PR DESCRIPTION
This changeset upgrades the composite action to use upload-artifact@v4, which could be considered a breaking change as artifact upload is now immutable and will fail if an artifact is uploading using the name of one that is already created.

https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

**Fortunately, this problem occur in consumers of action-autobuild** as the platfom name is baked into autobuild package and resulting artifact names.