### PR TITLE
Fix vcs_branch provided by package description

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -98,10 +98,6 @@ runs:
       uses: actions/checkout@v4
       if: inputs.checkout
       with:
-        # Work around the fact that in the context of a pull request github.sha
-        # references a dynamic merge commit rather than the branch head
-        # https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
         fetch-depth: 0 # Fetch all history for SCM version
         submodules: recursive
 
@@ -168,11 +164,7 @@ runs:
     - name: Determine branch
       id: which-branch
       shell: bash
-      run: |
-        # in real use, 'git branch -r --contains' should produce a single line,
-        # but our self-tests can emit more than one
-        branch="$(git branch -r --contains ${{ steps.sha.outputs.long }} | head -n 1)"
-        echo "branch=${branch#*/}" >> $GITHUB_OUTPUT
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
 
     - name: Run autobuild
       shell: ${{ steps.shell.outputs.shell }}
@@ -187,6 +179,7 @@ runs:
         AUTOBUILD_VARIABLES_FILE: ${{ github.workspace }}/.build-variables/variables
         AUTOBUILD_VCS_BRANCH: ${{ steps.which-branch.outputs.branch || github.ref_name }}
         AUTOBUILD_VCS_INFO: "true"
+        AUTOBUILD_VCS_REVISION: ${{ steps.sha.outputs.long }}
         BUILD_ID: ${{ inputs.build-id }}
         CONFIGURATION: ${{ inputs.configuration }}
         PLATFORM: ${{ inputs.platform }}

--- a/action.yaml
+++ b/action.yaml
@@ -180,6 +180,7 @@ runs:
         AUTOBUILD_VCS_BRANCH: ${{ steps.which-branch.outputs.branch || github.ref_name }}
         AUTOBUILD_VCS_INFO: "true"
         AUTOBUILD_VCS_REVISION: ${{ steps.sha.outputs.long }}
+        AUTOBUILD_VCS_URL: ${{ github.repositoryUrl }}
         BUILD_ID: ${{ inputs.build-id }}
         CONFIGURATION: ${{ inputs.configuration }}
         PLATFORM: ${{ inputs.platform }}


### PR DESCRIPTION
This action has been generating vcs_branch=HEAD in many situations due to the output of the git command it uses:

```
origin/HEAD -> origin/main
origin/main
origin/shell-override
```

Let's simplify this by using the branch and sha from the github action context.

Example autobuild-package.xml:
```xml
<?xml version="1.0" ?>
<llsd>
<map>
    <key>version</key>
    <string>1</string>
    <key>type</key>
    <string>metadata</string>
    <key>build_id</key>
    <string>7736889091</string>
    <key>platform</key>
    <string>linux64</string>
    <key>configuration</key>
    <string>default</string>
    <key>package_description</key>
    <map>
      <key>license</key>
      <string>MIT</string>
      <key>license_file</key>
      <string>LICENSE</string>
      <key>copyright</key>
      <string>Linden Research, Inc.</string>
      <key>version</key>
      <string>1.0.0</string>
      <key>name</key>
      <string>action-autobuild</string>
      <key>vcs_branch</key>
      <string>signal/fix-branch</string>
      <key>vcs_revision</key>
      <string>58dbe053780f169027045b8312e423ce13648559</string>
      <key>vcs_url</key>
      <string>git://github.com/secondlife/action-autobuild.git</string>
      <key>description</key>
      <string>common</string>
    </map>
    <key>manifest</key>
    <array>
      <string>content.txt</string>
      <string>LICENSE</string>
</array>
  </map>
```