### PR TITLE
Rename mysys2 parameters to msys2

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -51,9 +51,9 @@ inputs:
     type: string
     description: Version of autobuild to install
     default: 3.*
-  mysys2-packages:
+  msys2-packages:
     type: string
-    description: Additional mysys2 packages to install
+    description: Additional msys2 packages to install
   platform:
     type: string
     description: Autobuild platform
@@ -140,10 +140,10 @@ runs:
           pip install "autobuild @ git+https://github.com/secondlife/autobuild@$VERSION"
         fi
 
-    - name: Setup mysys2
-      if: ${{ runner.os == 'Windows' && inputs.mysys2-packages }}
+    - name: Setup msys2
+      if: ${{ runner.os == 'Windows' && inputs.msys2-packages }}
       shell: bash
-      run: pacman -Sy --noconfirm ${{ inputs.mysys2-packages }}
+      run: pacman -Sy --noconfirm ${{ inputs.msys2-packages }}
 
     - name: Cache installables
       uses: actions/cache@v4

--- a/action.yaml
+++ b/action.yaml
@@ -143,7 +143,9 @@ runs:
     - name: Setup msys2
       if: ${{ runner.os == 'Windows' && inputs.msys2-packages }}
       shell: bash
-      run: pacman -Sy --noconfirm ${{ inputs.msys2-packages }}
+      env:
+        MSYS2_PACKAGES: ${{ inputs.msys2-packages }}
+      run: pacman -Sy --noconfirm "$MSYS2_PACKAGES"
 
     - name: Cache installables
       uses: actions/cache@v4


### PR DESCRIPTION
Note that actually _using_ the parameter doesn't work right now unless you already had msys2 set up.

I verified that nobody but me is currently using this parameter anyway.